### PR TITLE
Feat/#12 토스트 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "13.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-toastify": "^9.1.2",
     "recoil": "^0.7.7",
     "styled-components": "^6.0.0-beta.12"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import { PropsWithChildren } from "react";
 
 import { AppProvider, StyledComponentsRegistry } from "@/libs";
 
+import { Toast } from "@/components";
+
 export const metadata = {
   title: "아하철이형",
   description: "아하철이형_웹",
@@ -33,6 +35,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <StyledComponentsRegistry>
           <AppProvider>{children}</AppProvider>
         </StyledComponentsRegistry>
+        <Toast />
       </body>
     </html>
   );

--- a/src/components/SomeComponent/SomeComponent.tsx
+++ b/src/components/SomeComponent/SomeComponent.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
 
 import { useSampleAtom } from "@/atoms";
 
-import { useSample } from "@/hooks";
+import { useSample, useToast } from "@/hooks";
 
 import * as S from "./styled";
 
@@ -20,6 +20,7 @@ export const fetchSample = async () => {
 };
 
 export default function SomeComponent({ someProp }: Props) {
+  const toast = useToast();
   const { sample } = useSample();
   const { sample: sampleAtom, setSample: setSampleAtom } = useSampleAtom();
 
@@ -38,7 +39,17 @@ export default function SomeComponent({ someProp }: Props) {
       <span>{someProp}</span>
       <span>{sample}</span>
       <span>{sampleAtom}</span>
-      <S.CustomBtn>hello world</S.CustomBtn>
+      <S.CustomBtn
+        onClick={() =>
+          toast.error(
+            <>
+              제목은 <strong>40자</strong> 이내로 작성해주세요.
+            </>
+          )
+        }
+      >
+        hello world
+      </S.CustomBtn>
     </S.Paragraph>
   );
 }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import * as S from "./styled";
+
+export default function Toast() {
+  return (
+    <S.Toast position="top-center" limit={1} closeButton={false} autoClose={2500} hideProgressBar />
+  );
+}

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { default as Toast } from "./Toast";

--- a/src/components/Toast/styled.ts
+++ b/src/components/Toast/styled.ts
@@ -1,0 +1,40 @@
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import styled from "styled-components";
+
+import { theme } from "@/styles";
+import { fonts } from "@/styles/themes/foundations";
+
+export const Toast = styled(ToastContainer)`
+  .Toastify__toast {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 360px;
+    height: 60px;
+    padding: 20px;
+    border-radius: 20px;
+    color: ${theme.colors.primary};
+    background-color: ${theme.colors.secondary};
+  }
+
+  .Toastify__toast-body {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0;
+    white-space: pre-line;
+
+    ${fonts.regular16}
+
+    b, strong {
+      ${fonts.bold16}
+    }
+  }
+
+  &.Toastify__toast-container--top-center {
+    top: 20px;
+  }
+`;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Toast";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useSample } from "./useSample";
+export { default as useToast } from "./useToast";

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,21 @@
+import { toast, ToastOptions } from "react-toastify";
+
+const useToast = () => {
+  const success = (content: React.ReactNode, option?: ToastOptions) => {
+    toast.success(content, {
+      // icon: <Image src="/images/??" width={20} height={20} />,
+      ...option,
+    });
+  };
+
+  const error = (content: React.ReactNode, option?: ToastOptions) => {
+    toast.error(content, {
+      // icon: <Image src="/images/??" width={20} height={20} />,
+      ...option,
+    });
+  };
+
+  return { success, error };
+};
+
+export default useToast;

--- a/src/styles/themes/foundations/fonts.ts
+++ b/src/styles/themes/foundations/fonts.ts
@@ -19,6 +19,12 @@ export const fonts = {
     font-family: Pretendard;
     line-height: 1.35714;
   `,
+  regular16: css`
+    font-size: 1.6rem;
+    font-weight: 400;
+    font-family: Pretendard;
+    line-height: 1.35714;
+  `,
   medium14: css`
     font-size: 1.4rem;
     font-weight: 500;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,11 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -3238,6 +3243,13 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-toastify@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.2.tgz#293aa1f952240129fe485ae5cb2f8d09c652cf3f"
+  integrity sha512-PBfzXO5jMGEtdYR5jxrORlNZZe/EuOkwvwKijMatsZZm8IZwLj01YvobeJYNjFcA6uy6CVrx2fzL9GWbhWPTDA==
+  dependencies:
+    clsx "^1.1.1"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
#12 

토스트의 경우 직접 제작하는 것보다 상용 라이브러리를 도입하는 것이 훨씬 간편하다고 판단했습니당.

다양한 라이브러리 중 react-toastify를 선택했는데, 타 라이브러리보다 점유율이 높고 사용해본 결과 커스텀 기능들이 간편했던 기억이 있어서 선택했습니다.

---
피그마 시안 상, 제목을 입력해주세요. 내용을 입력해주세요. 등 같은 메시지에 특정 단어에 bold 처리가 되어있는 부분이 있습니다.
단순 텍스트로만 보이진 않아 컴포넌트 자체를 주입할 수 있는 구조로 만들었습니다.

성공 toast, 에러 toast로 분리되어있으며

useToast라는 훅에서 toast만 가져와서 그대로 사용하면 됩니다.

(자동 꺼짐 2.5초, 클릭 시 꺼짐 기능은 유지하고있습니다.)
기타 옵션은 훅에서 불러오는 함수를 통해 주입 가능합니다.

---

https://user-images.githubusercontent.com/62434898/229358947-579a4035-34f6-4b54-b477-471238a0b0ed.mov


아래는 사용법에 대한 예시 코드입니다.

- 단순 텍스트만 노출할 시(성공, 에러)
```tsx
....
const toast = useToast();

...

toast.success("성공 했습니다.");

toast.error("실패 했습니다.")
```

- 강조된 단어가 포함된 텍스트를 노출할 시(성공, 에러) - b 혹은 strong 태그 사용
```tsx
....
const toast = useToast();

...

toast.success(<><b>성공</b> 했습니다.</>);

toast.error(<><b>실패</b> 했습니다.</>)
```

- 두 줄 이상의 텍스트를 노출할 시(성공, 에러) - br 태그 사용
```tsx
....
const toast = useToast();

...

toast.success(<>성공 <br/> 했습니다.</>);

toast.error(<>실패 <br/> 했습니다.</>)
```

---
기타

아이콘 svg의 컴포넌트화가 되어있지 않아 아이콘 부분은 적용하지 않았습니다😅