### PR TITLE
docs: 공통 FE BE 컨벤션 문서 분리

### DIFF
--- a/docs/refactor/BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md
+++ b/docs/refactor/BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md
@@ -1,0 +1,57 @@
+# Backend/DB/Infra Execution Checklist
+
+Last Updated: 2026-02-18
+Scope: Ahhachul backend stack
+
+## A. 시작 전(Pre-flight)
+
+- [ ] 현재 AWS 계정이 Ahhachul 계정인지 확인했다.
+- [ ] `aws sts get-caller-identity` 결과가 금지 계정(`419547990266`, `hb.lee@bodycodi.com`)이 아님을 확인했다.
+- [ ] 작업 대상 레포(`ahhachul_backend`, `ahachul_data`, `ahachul_secret`)와 영향 범위를 명확히 했다.
+- [ ] API/DB/시크릿 변경 여부를 미리 분류했다.
+
+## B. 설계/구현 체크
+
+- [ ] `ahhachul_backend`는 헥사고날 구조(`adapter/port/service/domain`)를 유지했다.
+- [ ] Controller는 `CommonResponse` 계약을 유지했다.
+- [ ] Request DTO → `toCommand(...)` 변환 패턴을 유지했다.
+- [ ] 예외는 `ResponseCode + *Exception` 계층 규칙을 따랐다.
+- [ ] 페이지네이션은 `PageInfoDto` 규칙을 유지했다.
+- [ ] DB 스키마 변경은 Flyway 마이그레이션 파일로 반영했다.
+- [ ] 시크릿 값 하드코딩 없이 `ahachul_secret`/env 기반으로 처리했다.
+- [ ] 데이터 크롤링 출력 스키마 변경 시 소비자 영향(consumer/backend) 분석을 남겼다.
+
+## C. 검증(Validation Gate)
+
+- [ ] backend 컴파일/테스트를 수행했다.
+- [ ] 주요 API 흐름(인증, 게시글, 댓글, 신고 등) 회귀 영향이 없는지 확인했다.
+- [ ] 시크릿 키명 변경 시 런타임 로딩 실패 가능성을 검토했다.
+- [ ] 배포 워크플로 변경 시 롤백 절차를 함께 검증했다.
+
+## D. PR/기록
+
+- [ ] 변경 이유와 범위를 PR에 명확히 기록했다.
+- [ ] 민감 정보(토큰/키/ARN 상세값)를 PR/로그에 노출하지 않았다.
+- [ ] 관련 이슈/작업 단위를 연결했다.
+- [ ] 본 체크리스트와 룰북 업데이트 필요 여부를 확인했다.
+
+## E. 권장 명령
+
+```bash
+# AWS 계정 확인
+aws sts get-caller-identity
+
+# backend 기본 검증(레포 루트 기준)
+./gradlew test
+
+# data repo 기본 실행 예시
+python main.py -o ca
+python main.py -o un
+python main.py -o ad -d 20260101
+```
+
+## F. 실패 시 중단 조건
+
+- AWS 계정 불일치 상태에서 실제 리소스 접근이 필요한 명령을 실행하려는 경우 즉시 중단.
+- 시크릿 값이 필요하지만 안전한 소스(ahachul_secret/env) 없이 하드코딩하려는 경우 즉시 중단.
+- Flyway 없이 DB 수동 변경으로 진행하려는 경우 즉시 중단.

--- a/docs/refactor/BACKEND_DB_INFRA_RULEBOOK.md
+++ b/docs/refactor/BACKEND_DB_INFRA_RULEBOOK.md
@@ -1,0 +1,144 @@
+# Ahhachul Backend/DB/Infra Rulebook
+
+Last Updated: 2026-02-18
+Scope: `ahhachul_backend`, `ahachul_data`, `ahachul_secret`
+Owner: Codex + createhb21
+
+## 0. 계정/보안 최우선 규칙
+
+- 금지: Ahhachul 작업에서 터미널 기본 `default` AWS 계정(회사 계정) 사용.
+- 확인된 금지 계정: `Account 419547990266`, `ARN hb.lee@bodycodi.com`.
+- 원칙: Ahhachul 전용 프로필/자격증명만 사용하고, 작업 시작 전에 항상 STS로 계정 확인.
+- 실행 전 체크:
+  - `aws sts get-caller-identity`
+  - 필요 시 `AWS_PROFILE=<ahhachul-profile>`를 명시해 명령 실행.
+
+## 1. ahhachul_backend 아키텍처/컨벤션
+
+### 1.1 모듈 구조
+
+- `core`: 도메인 엔티티/영속성/공통 유틸/에러 코드/Flyway.
+- `application`: API Controller, Service, 인터셉터/인증, 외부 클라이언트.
+- `scheduler`: 배치/스케줄링 작업.
+- `consumer`: Redis Stream 기반 컨슈머.
+
+### 1.2 패키지 구조(헥사고날)
+
+- 도메인 기준 패키지 구성:
+  - `<domain>/adapter/in`, `<domain>/adapter/out`
+  - `<domain>/application/port/in`, `<domain>/application/port/out`
+  - `<domain>/application/service`
+  - `<domain>/domain`
+- 신규 기능도 동일한 구조 유지.
+
+### 1.3 API 계층 규칙
+
+- API prefix는 `/v1/...` 유지.
+- Controller 응답은 `CommonResponse.success(...)`/`CommonResponse.fail(...)` 패턴 사용.
+- Request DTO는 `toCommand(...)`를 통해 UseCase 커맨드로 변환.
+- 인증은 `@Authentication(required = true|false)` 기반 정책 사용.
+
+### 1.4 에러/예외 규칙
+
+- 에러 코드는 `ResponseCode` enum 단일 소스 사용.
+- 예외 타입은 레이어별로 구분 유지:
+  - `CommonException`
+  - `AdapterException`
+  - `PortException`
+  - `DomainException`
+  - `BusinessException`
+- 전역 핸들러(`CommonExceptionHandler`)에서 `CommonResponse`로 변환.
+
+### 1.5 페이지네이션/토큰
+
+- 커서 기반 응답은 `PageInfoDto<T>` 패턴 유지.
+- page token encode/decode 규칙은 기존 유틸 재사용, 임의 포맷 추가 금지.
+
+### 1.6 DB/Flyway 규칙
+
+- 마이그레이션 위치: `core/src/main/resources/db/migration`.
+- 시드 데이터 위치: `core/src/main/resources/db/seed`.
+- 버전 파일명 패턴: `VYYYYMMDDHHmm__description.sql`.
+- 스키마 변경은 반드시 Flyway로만 반영(수동 DB 수정 후 미기록 금지).
+
+### 1.7 빌드/런타임 규칙
+
+- Java 17, Kotlin 1.7.22, Spring Boot 3.0.4 기반.
+- `build.gradle.kts`의 `copySecret`/`copyTestSecret` 태스크로 `../ahachul_secret` 구성 파일 동기화.
+- Secret은 코드 레포에 하드코딩 금지.
+
+### 1.8 협업 규칙(기존 팀 룰)
+
+- 브랜치 전략: `main` → `develop` → `feature/#issue`, `hotfix`.
+- 이슈 템플릿 기반 작업(`bug`, `feature`, `refactor`, `discussion`).
+- 기존 커밋 문화: gitmoji + 이슈 번호.
+
+## 2. ahachul_data 아키텍처/컨벤션
+
+### 2.1 역할
+
+- Lost112/뉴스 크롤링 및 데이터 산출(JSON) + Redis Stream/S3 연계.
+
+### 2.2 실행 규칙
+
+- 진입점: `main.py`
+- 옵션 규칙:
+  - `-o ca`: 전체 크롤링
+  - `-o un`: 신규 업데이트
+  - `-o ad -d YYYYMMDD`: 특정 일자 이후
+
+### 2.3 환경변수 기반 설정
+
+- `config.py`에서 S3/Redis 값 로드.
+- 대표 키: `access-key`, `secret-key`, `bucket-name`, `region`, `host`, `port`, `stream`, `password`.
+- 원칙: 자격증명은 로컬 env 또는 안전한 시크릿 매니저에서만 주입.
+
+### 2.4 산출물 규칙
+
+- 산출 파일: `datas/all.json`, `datas/subway_news_data.json`.
+- 스키마 변경 시 소비자(backend/consumer) 영향도 문서화 필수.
+
+## 3. ahachul_secret 컨벤션
+
+### 3.1 저장 구조
+
+- 환경별 분리 파일 유지:
+  - `application-local.yml`
+  - `application-dev.yml`
+  - `application-test.yml`
+
+### 3.2 키 네임스페이스 규칙
+
+- 상위 네임스페이스 일관 유지:
+  - `spring.*`
+  - `jwt.*`
+  - `oauth.*`
+  - `cloud.aws.*`
+  - `public-data.*`
+  - `resilience4j.*`
+  - `socket-server.*`
+  - `stream.*`
+
+### 3.3 변경 규칙
+
+- 시크릿 키명 변경 시 backend 코드/워크플로 영향 범위를 반드시 동시 검토.
+- 민감값은 문서/PR 본문/로그에 노출 금지.
+
+## 4. CI/CD/인프라 운영 규칙
+
+- backend 워크플로는 모듈 분리 배포 체계 유지:
+  - `dev-api-deploy.yml` (ECS/CodeDeploy)
+  - `dev-batch-deploy.yml` (EC2+SSM)
+  - `dev-consumer-deploy.yml` (EC2+SSM)
+  - `dev-cron-deploy.yml` (EC2+SSM)
+  - `pr-test.yml` (컴파일/테스트)
+- 신규 파이프라인 추가 시에도 모듈 단위 책임 분리를 유지.
+- 배포 스크립트 변경 시 롤백 경로와 실패 감지(health/command status)까지 포함.
+
+## 5. Codex 작업 가드레일(향후 백엔드/DB/인프라 공통)
+
+- 기존 동작을 바꾸는 리팩토링 금지(성능/안정성 중심).
+- 과도한 추상화 금지, 기존 패턴 우선 준수.
+- 변경하지 않은 코드의 주석/docstring/타입 어노테이션 임의 수정 금지.
+- API 계약/응답 포맷/에러 코드 일관성 우선.
+- 작업 전후 체크는 반드시 `BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md`를 따른다.

--- a/docs/refactor/BACKEND_DB_INFRA_RULEBOOK_CHANGELOG.md
+++ b/docs/refactor/BACKEND_DB_INFRA_RULEBOOK_CHANGELOG.md
@@ -1,0 +1,8 @@
+# Backend/DB/Infra Rulebook Changelog
+
+## 2026-02-18
+
+- `BACKEND_DB_INFRA_RULEBOOK.md` 최초 생성.
+- `ahhachul_backend`, `ahachul_data`, `ahachul_secret` 기준 아키텍처/컨벤션/운영 규칙 통합.
+- AWS 계정 안전 규칙(회사 default 계정 사용 금지) 명문화.
+- 실행 점검용 `BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md` 추가.

--- a/docs/refactor/CONVENTIONS.md
+++ b/docs/refactor/CONVENTIONS.md
@@ -1,50 +1,20 @@
-# Refactor Conventions
+# Refactor Conventions Hub
 
-## Workflow
+This document is the index for convention scopes.
 
-- Task lifecycle: `Todo -> InProgress -> QAReady -> ValidatorPass -> Committed -> Done`
-- Failure path: `* -> Rework -> QAReady`
-- One task per commit.
+## Convention Scopes
 
-## Git
+- Common: `docs/refactor/CONVENTIONS_COMMON.md`
+- FE (ahachul_web): `docs/refactor/CONVENTIONS_FE.md`
+- BE/DB/Infra stack (`ahhachul_backend`, `ahachul_data`, `ahachul_secret`): `docs/refactor/CONVENTIONS_BE.md`
 
-- Branch naming: `codex/<scope>`
-- Commit message format: `refactor(scope): [Task-ID] summary`
+## Precedence
 
-## Merge Policy
+1. Repository-specific rules (`CONVENTIONS_FE` or `CONVENTIONS_BE`)
+2. Common rules (`CONVENTIONS_COMMON`)
+3. Supplemental rulebooks (`FE_RULEBOOK`, validator checklist, runbooks)
 
-- Large refactor or operational hardening PRs: use `Merge Commit`.
-- Small feature/fix PRs with noisy intermediate commits: use `Squash Merge`.
-- Rebase policy is opt-in and limited:
-  - use `Rebase Merge` only when linear-history enforcement is explicitly required
-  - do not use `Rebase Merge` when commit hashes are referenced by governance docs (`SPRINT_BOARD`, `WORKLOG`, `DECISIONS`, etc.)
+## Notes
 
-## Engineering
-
-- Node: `20.13.0`
-- Package manager: `pnpm@9.x`
-- Dual-product strategy: keep both Vite and Next production-grade
-- Styling strategy: keep Emotion (Vite) and Tailwind (Next), share tokens and domain logic
-- Test strategy: Vitest (Vite), Jest (Next), common E2E/smoke gate
-- Nx tag model: `type:app`, `type:shared`, `type:tooling`
-- Boundary guard: `@nx/enforce-module-boundaries` must pass in `validate:lint`
-- Affected commands: `affected:type`, `affected:lint`, `affected:test`, `affected:build`
-- FE pod model: `FE Lead` + `FE Specialist A/B` with rule authority in `docs/refactor/FE_RULEBOOK.md`
-- FE rulebook change tracking is mandatory in `docs/refactor/FE_RULEBOOK_CHANGELOG.md`
-- FE meeting logs are timestamped files under `docs/refactor/fe-meetings` with index sync in `docs/refactor/FE_MEETING_LOG.md`
-- Utility convention baseline: shared utils are pure-first, `any`-free signatures, and parse/encode via platform primitives
-- React Query baseline: shared key factories/signature normalization + stale/gc-time and invalidation policy from `@ahhachul/domain`
-- Date formatting baseline: `formatDisplayDate` in `@ahhachul/utils` is the only app-layer entrypoint (lint-enforced)
-- Validation baseline: shared validators in `@ahhachul/utils` (`validateNickname`, `validateRequiredLexicalContent`, `isBlankText`) are mandatory
-- Number/price baseline: `formatDisplayNumber`/`formatDisplayPrice` in `@ahhachul/utils` are mandatory display entrypoints (lint-enforced)
-- Subway/common baseline: filter/line-map/arrival/content/file-extension helpers must use shared `@ahhachul/utils` contracts
-- Shared utility regression baseline: validate/format utility changes must ship with unit tests and pass `@ahhachul/utils:test`
-- Design-system color baseline: Vite/Next style layers must consume shared tokens from `@ahhachul/design-system`; direct inline hex is blocked in one-app and blocked in Vite Emotion/styled except approved legacy exception files.
-- Shared component baseline: promote UI primitives to `packages/ui` only when they pass FE Rulebook Rule 8 (cross-app reuse + presentational scope + Storybook external narrative value) and block merge unless `CI=1 pnpm ui:storybook:build` passes.
-- Micro style baseline: nested ternary is blocked globally, and obvious mirror derived-state effects are blocked by `validate:react-style`.
-- Validator guardrail baseline: `docs/refactor/REFACTORING_CRITICAL_RULES.md` must be checked before FE refactor sign-off.
-
-## Validation Authority
-
-- `Perfectionist Validator` is blocking authority.
-- No task proceeds until validator pass is recorded in `WORKLOG.md`.
+- If a task touches multiple repos, apply commit message rules per target repo.
+- Branch naming remains unified as `codex/<scope>`.

--- a/docs/refactor/CONVENTIONS_BE.md
+++ b/docs/refactor/CONVENTIONS_BE.md
@@ -1,0 +1,36 @@
+# BE/DB/Infra Conventions
+
+Scope: `ahhachul_backend`, `ahachul_data`, `ahachul_secret`
+
+## Commit Message
+
+- Source of truth: backend README collaboration rule.
+- Format: `gitmoji <commit message> (#issue number)`
+- Examples:
+  - `:sparkles: 로그인 API 개선 (#123)`
+  - `:bug: OAuth callback 예외 처리 수정 (#124)`
+  - `:memo: 시크릿 키 운영 문서 보강 (#125)`
+
+## Branch Strategy
+
+- Backend documented branch model:
+  - `main`
+  - `develop`
+  - `feature/<#issue number>`
+  - `hotfix`
+
+## Architecture/Coding Standards
+
+- Hexagonal + multi-module baseline (`core`, `application`, `scheduler`, `consumer`) must be preserved.
+- API response contract uses `CommonResponse` and `ResponseCode`.
+- Request DTO to use-case mapping follows `toCommand(...)`.
+- DB schema changes must use Flyway migrations under `core/src/main/resources/db/migration`.
+- Secret changes must be managed via `ahachul_secret` files, never hardcoded in code.
+
+## Operational Safety
+
+- Do not use company default AWS account for Ahhachul work.
+- Always verify identity before infra operations: `aws sts get-caller-identity`.
+- See detailed guardrails:
+  - `docs/refactor/BACKEND_DB_INFRA_RULEBOOK.md`
+  - `docs/refactor/BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md`

--- a/docs/refactor/CONVENTIONS_COMMON.md
+++ b/docs/refactor/CONVENTIONS_COMMON.md
@@ -1,0 +1,23 @@
+# Common Conventions
+
+## Workflow
+
+- Task lifecycle: `Todo -> InProgress -> QAReady -> ValidatorPass -> Committed -> Done`
+- Failure path: `* -> Rework -> QAReady`
+- One task per commit.
+
+## Branch
+
+- Branch naming: `codex/<scope>`
+
+## Merge Policy
+
+- Large refactor or operational hardening PRs: prefer `Merge Commit`.
+- Small feature or fix PRs with noisy intermediate commits: use `Squash Merge`.
+- `Rebase Merge` is opt-in only when linear history is explicitly required.
+- If commit hashes are referenced in governance docs (`SPRINT_BOARD`, `WORKLOG`, `DECISIONS`), avoid `Rebase Merge`.
+
+## Validation Authority
+
+- `Perfectionist Validator` is a blocking gate.
+- No task moves to `Done` until validator pass is recorded in `WORKLOG.md`.

--- a/docs/refactor/CONVENTIONS_FE.md
+++ b/docs/refactor/CONVENTIONS_FE.md
@@ -1,0 +1,29 @@
+# FE Conventions (ahachul_web)
+
+Scope: `ahachul_web` (Next.js + Vite + shared packages in this monorepo)
+
+## Commit Message
+
+- Format: `refactor(scope): [Task-ID] summary`
+- Example: `refactor(seo): [RF-1000] harden internal linking and sitemap`
+
+## Engineering Baseline
+
+- Node: `20.13.0`
+- Package manager: `pnpm@9.x`
+- Dual-product strategy: keep both Vite and Next production-grade.
+- Styling strategy: keep Emotion (Vite) and Tailwind (Next), share tokens and domain logic.
+- Test strategy: Vitest (Vite), Jest (Next), and common E2E/smoke gate.
+
+## Monorepo/Nx Baseline
+
+- Nx tag model: `type:app`, `type:shared`, `type:tooling`
+- Boundary guard: `@nx/enforce-module-boundaries` must pass in `validate:lint`.
+- Affected targets: `affected:type`, `affected:lint`, `affected:test`, `affected:build`.
+
+## FE Rulebook References
+
+- FE authority: `docs/refactor/FE_RULEBOOK.md`
+- Rulebook changelog: `docs/refactor/FE_RULEBOOK_CHANGELOG.md`
+- FE meeting log index: `docs/refactor/FE_MEETING_LOG.md`
+- Critical validator rule: `docs/refactor/REFACTORING_CRITICAL_RULES.md`


### PR DESCRIPTION
## 배경
현재 상위 오케스트레이션 체계(`@Ahhachul`)로 전환하면서, 백엔드 레포의 기존 개발 컨벤션(특히 커밋 규칙/아키텍처/운영 체크)을 문서로 명시적으로 고정할 필요가 있었습니다.