### PR TITLE
fix(auth): Next 로그인 콜백 요청을 백엔드 계약에 정합화

### DIFF
--- a/services/one-app/src/app/(auth)/login/callback/_lib/login.ts
+++ b/services/one-app/src/app/(auth)/login/callback/_lib/login.ts
@@ -21,11 +21,12 @@ export const LoginResponseSchema = z.object({
 
 export async function login({ code, type }: { type: SocialSignInType; code: string }) {
   const data = await fetchClient(API_PATHS.auth.login, {
+    method: 'POST',
     skipAuth: true,
-    params: {
+    body: JSON.stringify({
       providerCode: code,
       providerType: type,
-    },
+    }),
   });
 
   return LoginResponseSchema.parse(data);


### PR DESCRIPTION
## 변경 배경
Next.js 로그인 콜백에서 백엔드 인증 계약과 요청 형태가 달라 로그인 실패/500으로 이어질 수 있는 리스크가 있었습니다.

## 주요 변경 사항
- 로그인 콜백 요청을 `GET + query`에서 `POST + JSON body`로 변경
- 백엔드 `POST /v1/auth/login` 계약(`providerType`, `providerCode`)과 정확히 정합화

## 기대 효과
- OAuth callback 이후 로그인 요청 계약 불일치 제거
- 로그인 실패 시 불필요한 서버 에러(500) 발생 가능성 감소

## 검증
- 타입 체크 통과: `pnpm --filter @ahhachul/one-app type-check`
- 로컬 확인: Next.js 앱에서 Google 로그인 후 닉네임 설정 페이지 정상 이동

## 영향 범위
- `/services/one-app/src/app/(auth)/login/callback/_lib/login.ts`
